### PR TITLE
Use nullptr_t from std namespace instead of global namespace

### DIFF
--- a/include/impl_ptr.hpp
+++ b/include/impl_ptr.hpp
@@ -108,7 +108,7 @@ struct boost_impl_ptr_detail<user_type, more_types...>::base
 
     template<typename, typename...> friend struct boost_impl_ptr_detail;
 
-    base (nullptr_t) {}
+    base (std::nullptr_t) {}
 
     template<typename... arg_types>
     base(detail::in_place_type, arg_types&&... args)


### PR DESCRIPTION
Getting build errors without this with Clang, not with GCC.