### PR TITLE
onstack: support moving implementation

### DIFF
--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -54,7 +54,9 @@ struct detail::traits::base
 
     virtual void         destroy (impl_type*) const =0;
     virtual void          assign (impl_type*, impl_type const&) const { BOOST_ASSERT(0); }
+    virtual void          assign (impl_type* p, impl_type&& from) const { assign(p, from); }
     virtual impl_type* construct (void*, impl_type const&) const { BOOST_ASSERT(0); return nullptr; }
+    virtual impl_type* construct (void* vp, impl_type&& from) const { return construct(vp, from); }
 
     operator pointer()
     {
@@ -75,6 +77,23 @@ struct detail::traits::unique : base<unique<impl_type, allocator>, impl_type>
         alloc_type a;
 
         alloc_traits::destroy(a, p), a.deallocate(p, 1);
+    }
+    impl_type*
+    construct(void* vp, impl_type&& from) const override
+    {
+        alloc_type  a;
+        impl_type* ip = vp
+                      ? static_cast<impl_type*>(vp)
+                      : boost::to_address(a.allocate(1));
+
+        alloc_traits::construct(a, ip, std::move(from));
+
+        return ip;
+    }
+    void
+    assign(impl_type* p, impl_type&& from) const override
+    {
+        *p = std::move(from);
     }
 };
 
@@ -103,10 +122,27 @@ struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type
 
         return ip;
     }
+    impl_type*
+    construct(void* vp, impl_type&& from) const override
+    {
+        alloc_type  a;
+        impl_type* ip = vp
+                      ? static_cast<impl_type*>(vp)
+                      : boost::to_address(a.allocate(1));
+
+        alloc_traits::construct(a, ip, std::move(from));
+
+        return ip;
+    }
     void
     assign(impl_type* p, impl_type const& from) const override
     {
         *p = from;
+    }
+    void
+    assign(impl_type* p, impl_type&& from) const override
+    {
+        *p = std::move(from);
     }
 };
 

--- a/include/detail/onstack.hpp
+++ b/include/detail/onstack.hpp
@@ -33,12 +33,28 @@ struct detail::onstack // Proof of concept
         if (traits_)
             traits_->construct(storage_.address(), *o.get());
     }
+    onstack (this_type&& o) : traits_(o.traits_)
+    {
+        if (traits_)
+            traits_->construct(storage_.address(), std::move(*o.get()));
+    }
     this_type& operator=(this_type const& o)
     {
         /**/ if (!traits_ && !o.traits_);
         else if ( traits_ &&  o.traits_) traits_->assign(get(), *o.get());
         else if ( traits_ && !o.traits_) traits_->destroy(get());
         else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), *o.get());
+
+        traits_ = o.traits_;
+
+        return *this;
+    }
+    this_type& operator=(this_type&& o)
+    {
+        /**/ if (!traits_ && !o.traits_);
+        else if ( traits_ &&  o.traits_) traits_->assign(get(), std::move(*o.get()));
+        else if ( traits_ && !o.traits_) traits_->destroy(get());
+        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), std::move(*o.get()));
 
         traits_ = o.traits_;
 


### PR DESCRIPTION
This allows implementations to be moved if they support it.