### PR TITLE
Move 'null-state' behaviour to 'optional' and reject null-state behaviour in 'onstack'

### DIFF
--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -30,6 +30,12 @@ struct detail::copied
         this_type(impl).swap(*this);
     }
 
+    template<typename... arg_types>
+    copied(detail::in_place_type, arg_types&&... args)
+    {
+        emplace<impl_type>(std::forward<arg_types>(args)...);
+    }
+
    ~copied () { if (traits_) traits_->destroy(impl_); }
     copied () {}
     copied (impl_type* p) : impl_(p), traits_(traits_type()) {}

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -23,6 +23,8 @@ namespace boost
 
 namespace detail
 {
+    struct in_place_type {};
+
     template<typename type1 =void,
              typename type2 =void,
              typename type3 =void,

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -54,7 +54,9 @@ struct detail::traits::base
 
     virtual void         destroy (impl_type*) const =0;
     virtual void          assign (impl_type*, impl_type const&) const { BOOST_ASSERT(0); }
+    virtual void          assign (impl_type* p, impl_type&& from) const { assign(p, from); }
     virtual impl_type* construct (void*, impl_type const&) const { BOOST_ASSERT(0); return nullptr; }
+    virtual impl_type* construct (void* vp, impl_type&& from) const { return construct(vp, from); }
 
     operator pointer()
     {
@@ -75,6 +77,23 @@ struct detail::traits::unique : base<unique<impl_type, allocator>, impl_type>
         alloc_type a;
 
         alloc_traits::destroy(a, p), a.deallocate(p, 1);
+    }
+    impl_type*
+    construct(void* vp, impl_type&& from) const override
+    {
+        alloc_type  a;
+        impl_type* ip = vp
+                      ? static_cast<impl_type*>(vp)
+                      : boost::to_address(a.allocate(1));
+
+        alloc_traits::construct(a, ip, std::move(from));
+
+        return ip;
+    }
+    void
+    assign(impl_type* p, impl_type&& from) const override
+    {
+        *p = std::move(from);
     }
 };
 
@@ -103,10 +122,27 @@ struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type
 
         return ip;
     }
+    impl_type*
+    construct(void* vp, impl_type&& from) const override
+    {
+        alloc_type  a;
+        impl_type* ip = vp
+                      ? static_cast<impl_type*>(vp)
+                      : boost::to_address(a.allocate(1));
+
+        alloc_traits::construct(a, ip, std::move(from));
+
+        return ip;
+    }
     void
     assign(impl_type* p, impl_type const& from) const override
     {
         *p = from;
+    }
+    void
+    assign(impl_type* p, impl_type&& from) const override
+    {
+        *p = std::move(from);
     }
 };
 

--- a/include/detail/onstack.hpp
+++ b/include/detail/onstack.hpp
@@ -33,12 +33,28 @@ struct detail::onstack // Proof of concept
         if (traits_)
             traits_->construct(storage_.address(), *o.get());
     }
+    onstack (this_type&& o) : traits_(o.traits_)
+    {
+        if (traits_)
+            traits_->construct(storage_.address(), std::move(*o.get()));
+    }
     this_type& operator=(this_type const& o)
     {
         /**/ if (!traits_ && !o.traits_);
         else if ( traits_ &&  o.traits_) traits_->assign(get(), *o.get());
         else if ( traits_ && !o.traits_) traits_->destroy(get());
         else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), *o.get());
+
+        traits_ = o.traits_;
+
+        return *this;
+    }
+    this_type& operator=(this_type&& o)
+    {
+        /**/ if (!traits_ && !o.traits_);
+        else if ( traits_ &&  o.traits_) traits_->assign(get(), std::move(*o.get()));
+        else if ( traits_ && !o.traits_) traits_->destroy(get());
+        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), std::move(*o.get()));
 
         traits_ = o.traits_;
 

--- a/include/detail/onstack.hpp
+++ b/include/detail/onstack.hpp
@@ -5,7 +5,7 @@
 #ifndef IMPL_PTR_DETAIL_ONSTACK_HPP
 #define IMPL_PTR_DETAIL_ONSTACK_HPP
 
-#include "./detail.hpp"
+#include "./optional.hpp"
 
 namespace detail
 {
@@ -13,75 +13,13 @@ namespace detail
 }
 
 template<typename impl_type, typename size_type>
-struct detail::onstack // Proof of concept
+struct detail::onstack : detail::optional<impl_type, size_type> // Proof of concept
 {
-    template<typename T =void> struct allocator : std::allocator<T>
-    {
-        void deallocate(T*, size_t) {}
+    // Inherit all constructors (needed for in_place)
+    using detail::optional<impl_type, size_type>::optional;
 
-        template<typename Y> struct rebind { using other = allocator<Y>; };
-    };
-    using    this_type = onstack;
-    using storage_type = boost::aligned_storage<sizeof(size_type)>;
-    using  traits_type = traits::copyable<impl_type, allocator<>>;
-    using   traits_ptr = typename traits_type::pointer;
-
-   ~onstack () { if (traits_) traits_->destroy(get()); }
-    onstack () {}
-    onstack (this_type const& o) : traits_(o.traits_)
-    {
-        if (traits_)
-            traits_->construct(storage_.address(), *o.get());
-    }
-    onstack (this_type&& o) : traits_(o.traits_)
-    {
-        if (traits_)
-            traits_->construct(storage_.address(), std::move(*o.get()));
-    }
-    this_type& operator=(this_type const& o)
-    {
-        /**/ if (!traits_ && !o.traits_);
-        else if ( traits_ &&  o.traits_) traits_->assign(get(), *o.get());
-        else if ( traits_ && !o.traits_) traits_->destroy(get());
-        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), *o.get());
-
-        traits_ = o.traits_;
-
-        return *this;
-    }
-    this_type& operator=(this_type&& o)
-    {
-        /**/ if (!traits_ && !o.traits_);
-        else if ( traits_ &&  o.traits_) traits_->assign(get(), std::move(*o.get()));
-        else if ( traits_ && !o.traits_) traits_->destroy(get());
-        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), std::move(*o.get()));
-
-        traits_ = o.traits_;
-
-        return *this;
-    }
-
-    template<typename... arg_types>
-    onstack(detail::in_place_type, arg_types&&... args)
-    {
-        emplace<impl_type>(std::forward<arg_types>(args)...);
-    }
-
-    template<typename derived_type, typename... arg_types>
-    void
-    emplace(arg_types&&... args)
-    {
-        static_assert(sizeof(derived_type) <= storage_type::size, "");
-
-        ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
-        traits_ = traits_type();
-    }
-    impl_type* get () const { return traits_ ? (impl_type*) storage_.address() : nullptr; }
-
-    private:
-
-    storage_type storage_;
-    traits_ptr    traits_ = nullptr;
+    // Don't permit default construction (only way to get a null-state)
+    onstack () = delete;
 };
 
 #endif // IMPL_PTR_DETAIL_ONSTACK_HPP

--- a/include/detail/onstack.hpp
+++ b/include/detail/onstack.hpp
@@ -61,6 +61,12 @@ struct detail::onstack // Proof of concept
         return *this;
     }
 
+    template<typename... arg_types>
+    onstack(detail::in_place_type, arg_types&&... args)
+    {
+        emplace<impl_type>(std::forward<arg_types>(args)...);
+    }
+
     template<typename derived_type, typename... arg_types>
     void
     emplace(arg_types&&... args)

--- a/include/detail/optional.hpp
+++ b/include/detail/optional.hpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2008-2018 Vladimir Batov.
+// Use, modification and distribution are subject to the Boost Software License,
+// Version 1.0. See http://www.boost.org/LICENSE_1_0.txt.
+
+#ifndef IMPL_PTR_DETAIL_OPTIONAL_HPP
+#define IMPL_PTR_DETAIL_OPTIONAL_HPP
+
+#include "./detail.hpp"
+
+namespace detail
+{
+    template<typename, typename =void> struct optional;
+}
+
+template<typename impl_type, typename size_type>
+struct detail::optional // Proof of concept
+{
+    template<typename T =void> struct allocator : std::allocator<T>
+    {
+        void deallocate(T*, size_t) {}
+
+        template<typename Y> struct rebind { using other = allocator<Y>; };
+    };
+    using    this_type = optional;
+    using storage_type = boost::aligned_storage<sizeof(size_type)>;
+    using  traits_type = traits::copyable<impl_type, allocator<>>;
+    using   traits_ptr = typename traits_type::pointer;
+
+   ~optional () { if (traits_) traits_->destroy(get()); }
+    optional () {}
+    optional (this_type const& o) : traits_(o.traits_)
+    {
+        if (traits_)
+            traits_->construct(storage_.address(), *o.get());
+    }
+    optional (this_type&& o) : traits_(o.traits_)
+    {
+        if (traits_)
+            traits_->construct(storage_.address(), std::move(*o.get()));
+    }
+    this_type& operator=(this_type const& o)
+    {
+        /**/ if (!traits_ && !o.traits_);
+        else if ( traits_ &&  o.traits_) traits_->assign(get(), *o.get());
+        else if ( traits_ && !o.traits_) traits_->destroy(get());
+        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), *o.get());
+
+        traits_ = o.traits_;
+
+        return *this;
+    }
+    this_type& operator=(this_type&& o)
+    {
+        /**/ if (!traits_ && !o.traits_);
+        else if ( traits_ &&  o.traits_) traits_->assign(get(), std::move(*o.get()));
+        else if ( traits_ && !o.traits_) traits_->destroy(get());
+        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), std::move(*o.get()));
+
+        traits_ = o.traits_;
+
+        return *this;
+    }
+
+    template<typename... arg_types>
+    optional(detail::in_place_type, arg_types&&... args)
+    {
+        emplace<impl_type>(std::forward<arg_types>(args)...);
+    }
+
+    template<typename derived_type, typename... arg_types>
+    void
+    emplace(arg_types&&... args)
+    {
+        static_assert(sizeof(derived_type) <= storage_type::size, "");
+
+        ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
+        traits_ = traits_type();
+    }
+    impl_type* get () const { return traits_ ? (impl_type*) storage_.address() : nullptr; }
+
+    private:
+
+    storage_type storage_;
+    traits_ptr    traits_ = nullptr;
+};
+
+#endif // IMPL_PTR_DETAIL_OPTIONAL_HPP

--- a/include/detail/shared.hpp
+++ b/include/detail/shared.hpp
@@ -27,6 +27,12 @@ struct detail::shared : std::shared_ptr<impl_type>
     {
         base_ref(*this) = std::allocate_shared<derived_type>(alloc_type(), std::forward<arg_types>(args)...);
     }
+
+    template<typename... arg_types>
+    shared(detail::in_place_type, arg_types&&... args)
+    {
+        emplace<impl_type>(std::forward<arg_types>(args)...);
+    }
 };
 
 #endif // IMPL_PTR_DETAIL_SHARED_HPP

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -34,6 +34,12 @@ struct detail::unique
         this_type(impl).swap(*this);
     }
 
+    template<typename... arg_types>
+    unique(detail::in_place_type, arg_types&&... args)
+    {
+        emplace<impl_type>(std::forward<arg_types>(args)...);
+    }
+
    ~unique () { if (traits_) traits_->destroy(impl_); }
     unique () {}
     unique (impl_type* p) : impl_(p), traits_(traits_type()) {}

--- a/include/impl_ptr.hpp
+++ b/include/impl_ptr.hpp
@@ -10,6 +10,7 @@
 #include "./detail/unique.hpp"
 #include "./detail/copied.hpp"
 #include "./detail/onstack.hpp"
+#include "./detail/optional.hpp"
 #include "./detail/cow.hpp"
 
 // C1. Always use the impl_ptr<user_type>::implementation specialization.
@@ -36,11 +37,12 @@ struct boost_impl_ptr_detail
     template<typename> struct base;
 
     using impl_type = typename boost_impl_ptr_detail<user_type>::implementation; //C1
-    using    shared = base<detail:: shared <impl_type, more_types...>>;
-    using    unique = base<detail:: unique <impl_type, more_types...>>;
-    using    copied = base<detail:: copied <impl_type, more_types...>>;
-    using   onstack = base<detail::onstack <impl_type, more_types...>>;
-    using       cow = base<detail::    cow <impl_type, more_types...>>;
+    using    shared = base<detail::  shared <impl_type, more_types...>>;
+    using    unique = base<detail::  unique <impl_type, more_types...>>;
+    using    copied = base<detail::  copied <impl_type, more_types...>>;
+    using   onstack = base<detail:: onstack <impl_type, more_types...>>;
+    using  optional = base<detail::optional <impl_type, more_types...>>;
+    using       cow = base<detail::     cow <impl_type, more_types...>>;
 
     static user_type null()
     {

--- a/include/impl_ptr.hpp
+++ b/include/impl_ptr.hpp
@@ -5,16 +5,12 @@
 #ifndef IMPL_PTR_HPP
 #define IMPL_PTR_HPP
 
+#include "./detail/detail.hpp"
 #include "./detail/shared.hpp"
 #include "./detail/unique.hpp"
 #include "./detail/copied.hpp"
 #include "./detail/onstack.hpp"
 #include "./detail/cow.hpp"
-
-namespace detail
-{
-    struct in_place_type {};
-}
 
 // C1. Always use the impl_ptr<user_type>::implementation specialization.
 //     That allows the implementation developer to only declare/define one
@@ -112,8 +108,8 @@ struct boost_impl_ptr_detail<user_type, more_types...>::base
 
     template<typename... arg_types>
     base(detail::in_place_type, arg_types&&... args)
+        : impl_(in_place, std::forward<arg_types>(args)...)
     {
-        impl_.template emplace<implementation>(std::forward<arg_types>(args)...);
     }
 
     private: policy_type impl_;


### PR DESCRIPTION
This PR depends on #7.

This renames the current `onstack` policy to `optional` because it's behaviour closely models that of `std::optional`: provides internal storage, and optionally contains a value (or not: the null state). Then on top of that it implements a new `onstack` policy which explicitly rejects the null state at compile-time. This makes the `onstack` policy match, very closely, the behavior exhibited when no pimpl had been used at all. The only difference is that the size of this policy is still one pointer larger than that and possibly (likely) has larger alignment than necessary.