### PR TITLE
onstack: verify alignment requirement when constructing a new implementation

### DIFF
--- a/include/detail/onstack.hpp
+++ b/include/detail/onstack.hpp
@@ -71,7 +71,10 @@ struct impl_ptr_policy::onstack // Proof of concept
     void
     emplace(arg_types&&... args)
     {
-        static_assert(sizeof(derived_type) <= storage_type::size, "");
+        static_assert(sizeof(derived_type) <= sizeof(storage_type),
+                "Attempting to construct type larger than storage area");
+        static_assert((alignof(storage_type) % alignof(derived_type)) == 0,
+                "Attempting to construct type in storage area that does not have an integer multiple of the type's alignment requirement.");
 
         ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
         traits_ = traits_type();


### PR DESCRIPTION
This addresses part of #1 by asserting, at construction time, where the `impl_type` is complete, that the storage alignment is an integer multiple of the constructed type's alignment. This doesn't solve the problem of giving users the option to align at whatever boundary they wish, but at least it prevents one class of undefined behaviour at compile time.