### PR TITLE
onstack policy: make alignment configurable

### DIFF
--- a/doc/12_onstack_policy.qbk
+++ b/doc/12_onstack_policy.qbk
@@ -1,7 +1,10 @@
 [section On-Stack Implementation Policy]
 
- ...
- struct OnStack : boost::impl_ptr<OnStack, impl_ptr_policy::onstack, int[16]> { ... };
+The ['onstack'] policy allocates the implementation's memory inside of the containing class.
+It determines its size based on the first extra parameter.
+The default alignment (that of boost::aligned_storage) can be overridden by giving a type to take the alignment of as second parameter.
+
+ struct OnStack : boost::impl_ptr<OnStack, impl_ptr_policy::onstack, int[16], void*> { ... };
 
 Then ['OnStack] could be used no differently from other ['Pimpl]-based classes:
 
@@ -34,22 +37,23 @@ to
 or to
 
  // Stack-based implementation allocation
- struct Book : boost::impl_ptr<Book, impl_ptr_policy::onstack, char[64]> { ... };
+ struct Book : boost::impl_ptr<Book, impl_ptr_policy::onstack, void*[8], void*> { ... };
 
 with minimal or no disruption to the existing code. 
 
 Then, a restricted custom ['stack-based-implementation] policy (suggested by Giel van Schijndel) might be a further extension of impl_ptr_policy::onstack:
 
- template<typename impl_type, typename size_type>
- struct onstack_no_null : impl_ptr_policy::onstack<impl_type, size_type>
+ template<typename impl_type, typename size_type, typename align_type = void>
+ struct onstack_no_null : impl_ptr_policy::onstack<impl_type, size_type, align_type>
  {
-     using impl_ptr_policy::onstack<impl_type, size_type>::onstack;
+     // Inheriting base' constructors
+     using impl_ptr_policy::onstack<impl_type, size_type, align_type>::onstack;
 
      // Disable the null-state construction.
-     onstack_no_null(std::nullptr_t) =delete;
+     onstack_no_null(std::nullptr_t) = delete;
  };
  ...
- struct OnStack : boost::impl_ptr<OnStack, onstack_no_null, int[16]> { ... };
+ struct OnStack : boost::impl_ptr<OnStack, onstack_no_null, int[16], void*> { ... };
 
 to make sure of the following:
 

--- a/test/impl_onstack.cpp
+++ b/test/impl_onstack.cpp
@@ -25,6 +25,9 @@ template<> struct boost::impl_ptr<OnStack>::implementation
     mutable string trace_;
 };
 
+static_assert(sizeof(OnStack) == sizeof(boost::impl_ptr<OnStack>::implementation) + sizeof(void*),
+        "onstack, with a properly chosen size and alignment, should add only the size of a pointer to the implementation");
+
 OnStack::OnStack ()      : impl_ptr_type(in_place) {}
 OnStack::OnStack (int k) : impl_ptr_type(in_place, k) {}
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -68,7 +68,7 @@ struct Copied : boost::impl_ptr<Copied>::copied // Pure interface.
 };
 
 //struct OnStack : boost::impl_ptr<OnStack>::onstack<int[16]>
-struct OnStack : boost::impl_ptr<OnStack, impl_ptr_policy::onstack, int[16]>
+struct OnStack : boost::impl_ptr<OnStack, impl_ptr_policy::onstack, void*[5], void*>
 {
     OnStack ();
     OnStack (int);


### PR DESCRIPTION
This makes alignment configurable, to give the user the option to choose
something other than the default alignment, while simultaneously still
permitting the user to rely on the (sane) default.

This fixes #1.