### PR TITLE
Always inplace

### DIFF
--- a/doc/12_inplace_policy.qbk
+++ b/doc/12_inplace_policy.qbk
@@ -40,23 +40,24 @@ and then to
 
 with minimal or no disruption to the existing code. 
 
-Then, a restricted custom policy (suggested by Giel van Schijndel) might be a further extension of ['policy::inplace]:
+A restricted version of this policy can be used through ['policy::always_storage]:
 
- template<typename impl_type, typename size_type>
- struct inplace_no_null : policy::inplace<impl_type, size_type>
- {
-     using policy::inplace<impl_type, size_type>::inplace;
-
-     // Disable the null-state construction.
-     inplace_no_null(std::nullptr_t) =delete;
- };
- ...
- struct InPlace : boost::impl_ptr<InPlace, inplace_no_null, policy::storage<64>> { ... };
+ struct InPlace : boost::impl_ptr<InPlace, policy::inplace, policy::always_storage<64>> { ... };
 
 to make sure of the following:
 
  // The line below won't compile. InPlace does not have an uninitialized state.
  InPlace s13 = boost::impl_ptr<InPlace>::null();
+
+Additionally this takes advantage of the removed uninitialized state to remove all memory overhead associated with that:
+
+ template<> struct boost::impl_ptr<OnStack>::implementation
+ {
+   int data[16];
+ };
+ 
+ static_assert(sizeof(OnStack) == sizeof(boost::impl_ptr<OnStack>::implementation),
+     "Memory overhead where none was expected!");
 
 [endsect] 
 

--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -19,7 +19,7 @@ struct impl_ptr_policy::copied
     void
     emplace(arg_types&&... args)
     {
-        using   alloc_type = typename allocator::template rebind<derived_type>::other;
+        using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
         using alloc_traits = std::allocator_traits<alloc_type>;
 
         alloc_type       a;

--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -29,7 +29,7 @@ struct impl_ptr_policy::copied
         alloc_traits::construct(a, impl, std::forward<arg_types>(args)...);
 
         tmp.impl_   = impl;
-        tmp.traits_ = traits_type();
+        tmp.traits_ = traits_type::singleton();
 
         tmp.swap(*this);
     }

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -60,7 +60,7 @@ struct detail::traits::base
     virtual impl_type* construct (void*, impl_type const&) const { BOOST_ASSERT(0); return nullptr; }
     virtual impl_type* construct (void* p, impl_type&& from) const { return construct(p, from); }
 
-    operator pointer()
+    static pointer singleton()
     {
         static_assert(!std::is_same<this_type, traits_type>::value, "");
         static_assert(std::is_base_of<this_type, traits_type>::value, "");

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -72,21 +72,22 @@ struct detail::traits::base
 template<typename impl_type, typename allocator>
 struct detail::traits::unique : base<unique<impl_type, allocator>, impl_type>
 {
-    using   alloc_type = typename allocator::template rebind<impl_type>::other;
+    using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
     using alloc_traits = std::allocator_traits<alloc_type>;
 
     void destroy(impl_type* p) const override
     {
         alloc_type a;
 
-        alloc_traits::destroy(a, p), a.deallocate(p, 1);
+        alloc_traits::destroy(a, p);
+        alloc_traits::deallocate(a, p, 1);
     }
 };
 
 template<typename impl_type, typename allocator>
 struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type>
 {
-    using   alloc_type = typename allocator::template rebind<impl_type>::other;
+    using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
     using alloc_traits = std::allocator_traits<alloc_type>;
 
     void
@@ -94,7 +95,8 @@ struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type
     {
         alloc_type a;
 
-        alloc_traits::destroy(a, p), a.deallocate(p, 1);
+        alloc_traits::destroy(a, p);
+        alloc_traits::deallocate(a, p, 1);
     }
     impl_type*
     construct(void* vp, impl_type const& from) const override
@@ -102,7 +104,7 @@ struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type
         alloc_type  a;
         impl_type* ip = vp
                       ? static_cast<impl_type*>(vp)
-                      : boost::to_address(a.allocate(1));
+                      : boost::to_address(alloc_traits::allocate(a, 1));
 
         alloc_traits::construct(a, ip, from);
 
@@ -114,7 +116,7 @@ struct detail::traits::copyable : base<copyable<impl_type, allocator>, impl_type
         alloc_type  a;
         impl_type* ip = vp
                       ? static_cast<impl_type*>(vp)
-                      : boost::to_address(a.allocate(1));
+                      : boost::to_address(alloc_traits::allocate(a, 1));
 
         alloc_traits::construct(a, ip, std::move(from));
 

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -66,7 +66,7 @@ template<typename impl_type> struct impl_ptr_policy::always_storage<s, a>::type
                 "Attempting to construct type in storage area that does not have an integer multiple of the type's alignment requirement.");
 
         ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
-        set_traits(traits_type());
+        set_traits(traits_type::singleton());
     }
 
     private:
@@ -90,7 +90,7 @@ template<typename impl_type> struct impl_ptr_policy::storage<s, a>::type
     void emplace(arg_types&&... args)
     {
         base::template emplace<derived_type>(std::forward<arg_types>(args)...);
-        set_traits(traits_type());
+        set_traits(traits_type::singleton());
     }
 
     private:

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -84,6 +84,11 @@ struct impl_ptr_policy::inplace // Proof of concept
         static_assert((alignof(storage_type) % alignof(derived_type)) == 0,
                 "Attempting to construct type in storage area that does not have an integer multiple of the type's alignment requirement.");
 
+        if (traits_)
+        {
+            traits_->destroy(get());
+            traits_ = nullptr;
+        }
         ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
         traits_ = traits_type();
     }

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2008-2018 Vladimir Batov.
+// Copyright (c) 2017      Giel van Schijndel.
 // Use, modification and distribution are subject to the Boost Software License,
 // Version 1.0. See http://www.boost.org/LICENSE_1_0.txt.
 
@@ -10,11 +11,20 @@
 
 namespace impl_ptr_policy
 {
-    template<typename, typename> struct inplace;
+    template<typename impl_type, typename> struct inplace;
+    template<size_t s, size_t a =std::size_t(-1)> struct always_storage
+    {
+        static size_t constexpr size = s;
+        static size_t constexpr alignment = a;
+        static bool   constexpr has_null_state = false;
+        template<typename> struct type;
+    };
     template<size_t s, size_t a =std::size_t(-1)> struct storage
     {
         static size_t constexpr size = s;
         static size_t constexpr alignment = a;
+        static bool   constexpr has_null_state = true;
+        template<typename> struct type;
     };
     template<typename T =void> struct inplace_allocator
     {
@@ -26,45 +36,121 @@ namespace impl_ptr_policy
     };
 }
 
+template<size_t s, size_t a>
+template<typename impl_type> struct impl_ptr_policy::always_storage<s, a>::type
+{
+    using  traits_type = detail::traits::copyable<impl_type, inplace_allocator<>>;
+    using   traits_ptr = typename traits_type::pointer;
+    using storage_type = boost::aligned_storage<s, a>;
+
+    traits_ptr get_traits () const { return const_cast<type&>(*this).set_traits(); }
+    traits_ptr set_traits (const traits_ptr ptr = nullptr)
+    {
+        static traits_ptr traits;
+        // Assuming any non-null instance lives at least as long as any instance of this policy
+        if (ptr)
+            traits = ptr;
+        BOOST_ASSERT(traits != nullptr);
+        return traits;
+    }
+
+    void const* address() const { return storage_.address(); }
+    void      * address()       { return storage_.address(); }
+
+    template<typename derived_type, typename... arg_types>
+    void emplace(arg_types&&... args)
+    {
+        static_assert(sizeof(derived_type) <= sizeof(storage_type),
+                "Attempting to construct type larger than storage area");
+        static_assert((alignof(storage_type) % alignof(derived_type)) == 0,
+                "Attempting to construct type in storage area that does not have an integer multiple of the type's alignment requirement.");
+
+        ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
+        set_traits(traits_type());
+    }
+
+    private:
+    storage_type storage_;
+};
+
+template<size_t s, size_t a>
+template<typename impl_type> struct impl_ptr_policy::storage<s, a>::type
+    : private always_storage<s, a>::template type<impl_type>
+{
+    using         base = typename always_storage<s, a>::template type<impl_type>;
+    using  traits_type = typename base::traits_type;
+    using   traits_ptr = typename base::traits_ptr;
+
+    using base::address;
+
+    traits_ptr get_traits () const                  { return traits_; }
+    void       set_traits (const traits_ptr traits) { traits_ = traits; }
+
+    template<typename derived_type, typename... arg_types>
+    void emplace(arg_types&&... args)
+    {
+        base::template emplace<derived_type>(std::forward<arg_types>(args)...);
+        set_traits(traits_type());
+    }
+
+    private:
+    traits_ptr traits_ = nullptr;
+};
+
 template<typename impl_type, typename size_type>
 struct impl_ptr_policy::inplace // Proof of concept
 {
     using    this_type = inplace;
-    using storage_type = boost::aligned_storage<size_type::size, size_type::alignment>;
-    using  traits_type = detail::traits::copyable<impl_type, inplace_allocator<>>;
-    using   traits_ptr = typename traits_type::pointer;
+    using storage_type = typename size_type::template type<impl_type>;
 
-   ~inplace () { if (traits_) traits_->destroy(get()); }
-    inplace (std::nullptr_t) {}
-    inplace (this_type const& o) : traits_(o.traits_)
+   ~inplace ()
     {
-        if (traits_)
-            traits_->construct(storage_.address(), *o.get());
+        if (const auto traits = storage_.get_traits())
+            traits->destroy(get());
     }
-    inplace (this_type&& o) : traits_(o.traits_)
+    inplace (std::nullptr_t)
     {
-        if (traits_)
-            traits_->construct(storage_.address(), std::move(*o.get()));
+        static_assert(size_type::has_null_state, "Constructing null-state is prohibited.");
+    }
+    inplace (this_type const& o)
+    {
+        const auto traits = o.storage_.get_traits();
+        if (traits)
+            traits->construct(storage_.address(), *o.get());
+        storage_.set_traits(traits);
+    }
+    inplace (this_type&& o)
+    {
+        const auto traits = o.storage_.get_traits();
+        if (traits)
+            traits->construct(storage_.address(), std::move(*o.get()));
+        storage_.set_traits(traits);
     }
     this_type& operator=(this_type const& o)
     {
-        /**/ if (!traits_ && !o.traits_);
-        else if ( traits_ &&  o.traits_) traits_->assign(get(), *o.get());
-        else if ( traits_ && !o.traits_) traits_->destroy(get());
-        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), *o.get());
+        const auto traits = storage_.get_traits();
+        const auto o_traits = o.storage_.get_traits();
 
-        traits_ = o.traits_;
+        /**/ if (!traits && !o_traits);
+        else if ( traits &&  o_traits) traits->assign(get(), *o.get());
+        else if ( traits && !o_traits) traits->destroy(get());
+        else if (!traits &&  o_traits) o_traits->construct(storage_.address(), *o.get());
+
+        storage_.set_traits(o_traits);
 
         return *this;
     }
     this_type& operator=(this_type&& o)
     {
-        /**/ if (!traits_ && !o.traits_);
-        else if ( traits_ &&  o.traits_) traits_->assign(get(), std::move(*o.get()));
-        else if ( traits_ && !o.traits_) traits_->destroy(get());
-        else if (!traits_ &&  o.traits_) o.traits_->construct(storage_.address(), std::move(*o.get()));
+        const auto traits = storage_.get_traits();
+        const auto o_traits = o.storage_.get_traits();
 
-        traits_ = o.traits_;
+        /**/ if (!traits && !o_traits);
+        else if ( traits &&  o_traits) traits->assign(get(), std::move(*o.get()));
+        else if ( traits && !o_traits) traits->destroy(get());
+        else if (!traits &&  o_traits) o_traits->construct(storage_.address(), std::move(*o.get()));
+
+        storage_.set_traits(o_traits);
 
         return *this;
     }
@@ -72,32 +158,25 @@ struct impl_ptr_policy::inplace // Proof of concept
     template<typename... arg_types>
     inplace(detail::in_place_type, arg_types&&... args)
     {
-        emplace<impl_type>(std::forward<arg_types>(args)...);
+        storage_.template emplace<impl_type>(std::forward<arg_types>(args)...);
     }
 
     template<typename derived_type, typename... arg_types>
-    void
-    emplace(arg_types&&... args)
+    void emplace(arg_types&&... args)
     {
-        static_assert(sizeof(derived_type) <= sizeof(storage_type),
-                "Attempting to construct type larger than storage area");
-        static_assert((alignof(storage_type) % alignof(derived_type)) == 0,
-                "Attempting to construct type in storage area that does not have an integer multiple of the type's alignment requirement.");
-
-        if (traits_)
+        static_assert(size_type::has_null_state, "Emplacing to storage that doesn't support null-state is prohibited.");
+        if (const auto traits = storage_.get_traits())
         {
-            traits_->destroy(get());
-            traits_ = nullptr;
+            traits->destroy(get());
+            storage_.set_traits(nullptr);
         }
-        ::new (storage_.address()) derived_type(std::forward<arg_types>(args)...);
-        traits_ = traits_type();
+        return storage_.template emplace<derived_type>(std::forward<arg_types>(args)...);
     }
-    impl_type* get () const { return traits_ ? (impl_type*) storage_.address() : nullptr; }
+
+    impl_type* get () const { return storage_.get_traits() ? (impl_type*) storage_.address() : nullptr; }
 
     private:
-
     storage_type storage_;
-    traits_ptr    traits_ = nullptr;
 };
 
 #endif // IMPL_PTR_DETAIL_INPLACE_HPP

--- a/include/detail/shared.hpp
+++ b/include/detail/shared.hpp
@@ -19,7 +19,7 @@ struct impl_ptr_policy::shared : std::shared_ptr<impl_type>
                        1 <= sizeof...(more_types),
                        typename detail::types<more_types...>::first_type,
                        std::allocator<impl_type>>::type;
-    using alloc_type = typename allocator::template rebind<impl_type>::other;
+    using alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
     using   base_ref = std::shared_ptr<impl_type>&;
 
     template<typename derived_type, typename... arg_types>

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -23,7 +23,7 @@ struct impl_ptr_policy::unique
     void
     emplace(arg_types&&... args)
     {
-        using   alloc_type = typename allocator::template rebind<derived_type>::other;
+        using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
         using alloc_traits = std::allocator_traits<alloc_type>;
 
         alloc_type       a;

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -33,7 +33,7 @@ struct impl_ptr_policy::unique
         alloc_traits::construct(a, impl, std::forward<arg_types>(args)...);
 
         tmp.impl_   = impl;
-        tmp.traits_ = traits_type();
+        tmp.traits_ = traits_type::singleton();
 
         tmp.swap(*this);
     }

--- a/test/impl_always_inplace.cpp
+++ b/test/impl_always_inplace.cpp
@@ -1,0 +1,45 @@
+#include "./test.hpp"
+
+template<> struct boost::impl_ptr<AlwaysInPlace>::implementation
+{
+    using this_type = implementation;
+
+    implementation ()           : int_(0), trace_("AlwaysInPlace()"          ) {}
+    implementation (int k)      : int_(k), trace_("AlwaysInPlace(int)"       ) {}
+    implementation (int k, int) : int_(k), trace_("AlwaysInPlace(int, int)"  ) {}
+    implementation (Foo&)       : int_(0), trace_("AlwaysInPlace(Foo&)"      ) {}
+    implementation (Foo const&) : int_(0), trace_("AlwaysInPlace(Foo const&)") {}
+
+    implementation(this_type const& other)
+    :
+        int_(other.int_), trace_("AlwaysInPlace(AlwaysInPlace const&)")
+    {}
+    this_type& operator=(this_type const& other)
+    {
+        int_   = other.int_;
+        trace_ = "AlwaysInPlace::operator=(AlwaysInPlace const&)";
+
+        return *this;
+    }
+    int                 int_;
+    mutable const char* trace_;
+};
+
+static_assert(sizeof(AlwaysInPlace) == sizeof(boost::impl_ptr<AlwaysInPlace>::implementation),
+        "No memory size overhead for always_storage is permitted");
+static_assert(alignof(AlwaysInPlace) == alignof(boost::impl_ptr<AlwaysInPlace>::implementation),
+        "No memory alignment overhead for always_storage is permitted");
+
+AlwaysInPlace::AlwaysInPlace ()      : impl_ptr_type(in_place) {}
+AlwaysInPlace::AlwaysInPlace (int k) : impl_ptr_type(in_place, k) {}
+
+string AlwaysInPlace::trace () const { return *this ? (*this)->trace_ : "null"; }
+int    AlwaysInPlace::value () const { return (*this)->int_; }
+
+bool
+AlwaysInPlace::operator==(AlwaysInPlace const& that) const
+{
+    (*this)->trace_ = "AlwaysInPlace::operator==(AlwaysInPlace const&)";
+
+    return (*this)->int_ == that->int_;
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -222,7 +222,7 @@ test_unique()
 
 static
 void
-test_onstack()
+test_inplace()
 {
     InPlace s11 (3); BOOST_TEST(s11.value() == 3);
     InPlace s12 (5); BOOST_TEST(s12.value() == 5);
@@ -235,6 +235,23 @@ test_onstack()
 
     s11 = s12;          BOOST_TEST(s11.value() == 5);
     s11 = InPlace(6);   BOOST_TEST(s11.value() == 6);
+}
+
+static
+void
+test_always_inplace()
+{
+    AlwaysInPlace s11 (3); BOOST_TEST(s11.value() == 3);
+    AlwaysInPlace s12 (5); BOOST_TEST(s12.value() == 5);
+    AlwaysInPlace s13;
+
+    // Check that implementation is allocated on the stack.
+    BOOST_TEST((void*) &s11 == (void*) &*s11);
+    BOOST_TEST(bool(s13)); // Test op bool()
+    BOOST_TEST(!!s13);     // Test op!()
+
+    s11 = s12;                BOOST_TEST(s11.value() == 5);
+    s11 = AlwaysInPlace(6);   BOOST_TEST(s11.value() == 6);
 }
 
 static
@@ -270,7 +287,8 @@ main(int argc, char const* argv[])
     test_shared();
     test_copied();
     test_unique();
-    test_onstack();
+    test_inplace();
+    test_always_inplace();
     test_bool_conversions();
     test_runtime_polymorphic_behavior();
     test_swap();

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -83,6 +83,20 @@ struct InPlace : boost::impl_ptr<InPlace, policy::inplace, policy::storage<64>>
     int    value () const;
 };
 
+struct AlwaysInPlace : boost::impl_ptr<AlwaysInPlace, policy::inplace, policy::always_storage<sizeof(void*) * 2, alignof(void*)>>
+{
+    AlwaysInPlace ();
+    AlwaysInPlace (int);
+
+    // Value-semantics Pimpl must explicitly define comparison operators
+    // if it wants to be comparable. The same as normal classes do.
+    bool operator==(AlwaysInPlace const& o) const;
+    bool operator!=(AlwaysInPlace const& o) const { return !operator==(o); }
+
+    string trace () const;
+    int    value () const;
+};
+
 struct Base : boost::impl_ptr<Base>::shared
 {
     Base (int);


### PR DESCRIPTION
This moves the decision on whether to have a null state to the `size_type` template parameter of `inplace`. Specifically it requires two extra members in that template parameter: `has_null_state`, which must be a `constexpr bool`, that is `true` if and only if a null-state is permitted. Secondly it contains a `type` member which becomes the new storage type. It contains both the storage and handles storage of the traits pointer. It handles the traits pointer in such a way that this pointer is eliminated from the object when no null state is permitted, thus allowing zero memory overhead.

This builds on #10.