### PR TITLE
Refactor inplace policy

### DIFF
--- a/doc/12_inplace_policy.qbk
+++ b/doc/12_inplace_policy.qbk
@@ -40,9 +40,13 @@ and then to
 
 with minimal or no disruption to the existing code. 
 
-More so, if necessary, a restricted version of this policy can be deployed using ['policy::always_storage]:
+Note that it is necessary to specify the size, in bytes, with an extra ['policy::storage] argument.
+This is a template class which' first argument specifies the size and its optional second argument specifies alignment.
+The default alignment is at least the strictest alignment for any type of the given size.
 
- struct InPlace : boost::impl_ptr<InPlace, policy::inplace, policy::always_storage<64>> { ... };
+More so, if necessary, a restricted version of this policy can be deployed: ['policy::always_inplace]:
+
+ struct InPlace : boost::impl_ptr<InPlace, policy::always_inplace, policy::storage<64>> { ... };
 
 to make sure of the following:
 
@@ -50,11 +54,11 @@ to make sure of the following:
  // InPlace does not have an uninitialized 'null' state.
  InPlace s13 = boost::impl_ptr<InPlace>::null();
 
-An important property of such ['policy::inplace] deployment is that it creates a ['Pimpl]-enabled value-semantics class with ['no Pimpl-related memory overhead]:
+An important property of such ['policy::always_inplace] deployment is that it creates a ['Pimpl]-enabled value-semantics class with ['no Pimpl-related memory overhead]:
 
  template<> struct boost::impl_ptr<InPlace>::implementation
  {
-   int data[16];
+   std::int32_t data[16];
  };
  
  static_assert(sizeof(InPlace) == sizeof(boost::impl_ptr<InPlace>::implementation),

--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -46,7 +46,7 @@ struct impl_ptr_policy::copied
     copied (this_type const& o) : traits_(o.traits_)
     {
         if (traits_)
-            impl_ = traits_->construct(nullptr, *o.impl_);
+            impl_ = traits_->make(*o.impl_);
     }
 
     bool       operator< (this_type const& o) const { return impl_ < o.impl_; }
@@ -56,7 +56,7 @@ struct impl_ptr_policy::copied
         /**/ if ( impl_ ==  o.impl_);
         else if ( impl_ &&  o.impl_) traits_->assign(impl_, *o.impl_);
         else if ( impl_ && !o.impl_) traits_->destroy(impl_);
-        else if (!impl_ &&  o.impl_) impl_ = o.traits_->construct(nullptr, *o.impl_);
+        else if (!impl_ &&  o.impl_) impl_ = o.traits_->make(*o.impl_);
 
         traits_ = o.traits_;
 

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -113,21 +113,37 @@ struct detail::traits::copyable final : base<copyable<impl_type, allocator>, imp
     }
     impl_type* make(impl_type const& from) const override
     {
-        alloc_type        a;
-        impl_type* const ip = boost::to_address(alloc_traits::allocate(a, 1));
+        alloc_type  a;
+        const auto ip = alloc_traits::allocate(a, 1);
 
-        alloc_traits::construct(a, ip, from);
+        try
+        {
+            alloc_traits::construct(a, boost::to_address(ip), from);
+        }
+        catch (...)
+        {
+            alloc_traits::deallocate(a, ip, 1);
+            throw;
+        }
 
-        return ip;
+        return boost::to_address(ip);
     }
     impl_type* make(impl_type&& from) const override
     {
-        alloc_type        a;
-        impl_type* const ip = boost::to_address(alloc_traits::allocate(a, 1));
+        alloc_type  a;
+        const auto ip = alloc_traits::allocate(a, 1);
 
-        alloc_traits::construct(a, ip, std::move(from));
+        try
+        {
+            alloc_traits::construct(a, boost::to_address(ip), std::move(from));
+        }
+        catch (...)
+        {
+            alloc_traits::deallocate(a, ip, 1);
+            throw;
+        }
 
-        return ip;
+        return boost::to_address(ip);
     }
     void assign(impl_type* p, impl_type const& from) const override
     {

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -55,11 +55,11 @@ struct detail::traits::base
     virtual ~base() =default;
 
     virtual void         destroy (impl_type*) const =0;
-    virtual void          assign (impl_type*, impl_type const&) const { BOOST_ASSERT(0); }
+    virtual void          assign (impl_type*, impl_type const&) const { BOOST_ASSERT(!"not implemented"); }
     virtual void          assign (impl_type* p, impl_type&& from) const { assign(p, from); }
-    virtual void       construct (void*, impl_type const&) const { BOOST_ASSERT(0); }
+    virtual void       construct (void*, impl_type const&) const { BOOST_ASSERT(!"not implemented"); }
     virtual void       construct (void* p, impl_type&& from) const { return construct(p, from); }
-    virtual impl_type*      make (impl_type const&) const { BOOST_ASSERT(0); return nullptr; }
+    virtual impl_type*      make (impl_type const&) const { BOOST_ASSERT(!"not implemented"); return nullptr; }
     virtual impl_type*      make (impl_type&& from) const { return make(from); }
 
     static pointer singleton()

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -7,6 +7,7 @@
 #define IMPL_PTR_DETAIL_INPLACE_HPP
 
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <new>
 #include "./detail.hpp"
 
@@ -50,18 +51,21 @@ struct detail::static_traits
     using  traits_type = traits::copyable<impl_type, inplace_allocator<>>;
     using   traits_ptr = typename traits_type::pointer;
 
-    void construct_traits ()       { set_traits(traits_type::singleton()); }
-    traits_ptr get_traits () const { return const_cast<static_traits&>(*this).set_traits(); }
-    traits_ptr set_traits (const traits_ptr ptr = nullptr)
+    void construct_traits ()       { traits_ = traits_type::singleton(); }
+    traits_ptr get_traits () const { return traits_; }
+    void set_traits (const traits_ptr ptr)
     {
-        static traits_ptr traits;
-        // Assuming any non-null instance lives at least as long as any instance of this policy
-        if (ptr)
-            traits = ptr;
-        BOOST_ASSERT(traits != nullptr);
-        return traits;
+        boost::ignore_unused(ptr);
+        BOOST_ASSERT(ptr == traits_);
     }
+
+    private:
+    static traits_ptr traits_;
 };
+
+template<typename impl_type, typename storage_type>
+typename detail::static_traits<impl_type, storage_type>::traits_ptr
+detail::static_traits<impl_type, storage_type>::traits_ = nullptr;
 
 template<typename impl_type, typename storage_type>
 struct detail::local_traits

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -34,10 +34,10 @@ namespace detail
     template<typename T =void> struct inplace_allocator
     {
         using value_type = T;
-        void deallocate(T*, size_t) const noexcept {}
-        T* allocate(std::size_t) const { throw std::bad_alloc(); }
-        bool operator==(const inplace_allocator&) const noexcept { return true; }
-        bool operator!=(const inplace_allocator&) const noexcept { return false; }
+        [[noreturn]] T* allocate(std::size_t) const { throw std::bad_alloc(); }
+        constexpr void deallocate(T*, size_t) const noexcept {}
+        constexpr bool operator==(const inplace_allocator&) const noexcept { return true; }
+        constexpr bool operator!=(const inplace_allocator&) const noexcept { return false; }
     };
     template<typename, typename> struct static_traits;
     template<typename, typename> struct local_traits;

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -26,14 +26,22 @@ struct impl_ptr_policy::unique
         using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<derived_type>;
         using alloc_traits = std::allocator_traits<alloc_type>;
 
-        alloc_type       a;
-        this_type      tmp (nullptr);
-        derived_type* impl (boost::to_address(a.allocate(1)));
+        alloc_type    a;
+        this_type   tmp (nullptr);
+        const auto impl (alloc_traits::allocate(a, 1));
 
-        alloc_traits::construct(a, impl, std::forward<arg_types>(args)...);
+        try
+        {
+            alloc_traits::construct(a, boost::to_address(impl), std::forward<arg_types>(args)...);
+            tmp.traits_ = traits_type::singleton();
+        }
+        catch (...)
+        {
+            alloc_traits::deallocate(a, impl, 1);
+            throw;
+        }
 
-        tmp.impl_   = impl;
-        tmp.traits_ = traits_type::singleton();
+        tmp.impl_   = boost::to_address(impl);
 
         tmp.swap(*this);
     }

--- a/test/impl_always_inplace.cpp
+++ b/test/impl_always_inplace.cpp
@@ -26,9 +26,9 @@ template<> struct boost::impl_ptr<AlwaysInPlace>::implementation
 };
 
 static_assert(sizeof(AlwaysInPlace) == sizeof(boost::impl_ptr<AlwaysInPlace>::implementation),
-        "No memory size overhead for always_storage is permitted");
+        "No memory size overhead for always_inplace is permitted");
 static_assert(alignof(AlwaysInPlace) == alignof(boost::impl_ptr<AlwaysInPlace>::implementation),
-        "No memory alignment overhead for always_storage is permitted");
+        "No memory alignment overhead for always_inplace is permitted");
 
 AlwaysInPlace::AlwaysInPlace ()      : impl_ptr_type(in_place) {}
 AlwaysInPlace::AlwaysInPlace (int k) : impl_ptr_type(in_place, k) {}

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -83,7 +83,7 @@ struct InPlace : boost::impl_ptr<InPlace, policy::inplace, policy::storage<64>>
     int    value () const;
 };
 
-struct AlwaysInPlace : boost::impl_ptr<AlwaysInPlace, policy::inplace, policy::always_storage<sizeof(void*) * 2, alignof(void*)>>
+struct AlwaysInPlace : boost::impl_ptr<AlwaysInPlace, policy::always_inplace, policy::storage<sizeof(void*) * 2, alignof(void*)>>
 {
     AlwaysInPlace ();
     AlwaysInPlace (int);


### PR DESCRIPTION
This refactors the `inplace` policy (and renames it to `basic_inplace`) such that the possibility of a null-state is no longer part of the `size_type` template type parameter. Instead this can now be controlled by an extra boolean `has_null_state` template parameter. We then construct two template aliases `inplace` and `always_inplace` which differ in the value they pass on for `has_null_state` to `basic_inplace`.

The storage difference is now handled by a combined 'storage and traits' class. `basic_inplace` selects the correct version of that class depending on the value of its `has_null_state` template parameter.

Additionally this splits allocation and construction in the traits classes. This allows the compiler (when it can devirtualize calls) to completely eliminate memory allocation code for `basic_inplace` based pimpls.

In addition to that I've also added a bugfix: we would leak memory if construction failed, because we never called `deallocate` in that case. That's handled now, albeit in a non-RTTI fashion.