### PR TITLE
Traits and inplace refactor

### DIFF
--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -48,7 +48,7 @@ struct impl_ptr_policy::copied
     copied (this_type const& o)
     {
         if (o.impl_)
-            impl_.reset(traits_type::traits().construct(nullptr, *o.impl_));
+            impl_.reset(traits_type::construct(nullptr, *o.impl_));
     }
 
     bool       operator< (this_type const& o) const { return impl_ < o.impl_; }
@@ -56,9 +56,9 @@ struct impl_ptr_policy::copied
     this_type& operator= (this_type const& o)
     {
         /**/ if ( impl_ ==  o.impl_);
-        else if ( impl_ &&  o.impl_) traits_type::traits().assign(impl_.get(), *o.impl_);
+        else if ( impl_ &&  o.impl_) traits_type::assign(impl_.get(), *o.impl_);
         else if ( impl_ && !o.impl_) impl_.reset();
-        else if (!impl_ &&  o.impl_) impl_.reset(traits_type::traits().construct(nullptr, *o.impl_));
+        else if (!impl_ &&  o.impl_) impl_.reset(traits_type::construct(nullptr, *o.impl_));
 
         return *this;
     }

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -68,7 +68,7 @@ struct detail::basic_inplace // Proof of concept
    ~basic_inplace ()
     {
         if (exists())
-            traits_type::traits().destroy(get());
+            traits_type::destroy(get());
     }
     BOOST_CXX14_CONSTEXPR basic_inplace (std::nullptr_t)
     {
@@ -103,7 +103,7 @@ struct detail::basic_inplace // Proof of concept
         static_assert(exists_type(false) == false, "Emplacing to storage that doesn't support null-state is prohibited.");
         if (exists())
         {
-            traits_type::traits().destroy(get());
+            traits_type::destroy(get());
             set_exists(false);
         }
         return _construct<derived_type>(std::forward<arg_types>(args)...);
@@ -136,9 +136,9 @@ struct detail::basic_inplace // Proof of concept
         const bool o_exists =     o.exists();
 
         /**/ if (!exists && !o_exists);
-        else if ( exists &&  o_exists) traits_type::traits().assign(get(), std::forward<uref>(*o.get()));
-        else if ( exists && !o_exists) traits_type::traits().destroy(get());
-        else if (!exists &&  o_exists) traits_type::traits().construct(storage().address(), std::forward<uref>(*o.get()));
+        else if ( exists &&  o_exists) traits_type::assign(get(), std::forward<uref>(*o.get()));
+        else if ( exists && !o_exists) traits_type::destroy(get());
+        else if (!exists &&  o_exists) traits_type::construct(storage().address(), std::forward<uref>(*o.get()));
 
         set_exists(o_exists);
 

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -27,15 +27,13 @@ struct impl_ptr_policy::unique
         using   alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<derived_type>;
         using alloc_traits = std::allocator_traits<alloc_type>;
 
-        alloc_type     a;
-        derived_type* ap = alloc_traits::allocate(a, 1);
-        derived_type* ip = boost::to_address(ap);
+        alloc_type  a;
+        const auto ap = alloc_traits::allocate(a, 1);
 
         try
         {
-            alloc_traits::construct(a, ip, std::forward<arg_types>(args)...);
-
-            impl_ = ptr_type(ip, traits_type::singleton());
+            traits_type::emplace(a, ap, std::forward<arg_types>(args)...);
+            impl_.reset(ap);
         }
         catch (...)
         {
@@ -53,7 +51,7 @@ struct impl_ptr_policy::unique
    ~unique () = default;
     unique (std::nullptr_t) {}
 
-    unique (this_type&& o) { swap(o); }
+    unique (this_type&& o) = default;
     this_type& operator= (this_type&& o) { swap(o); return *this; }
 
     unique (this_type const&) =delete;


### PR DESCRIPTION
This moves all the singleton related stuff to the traits class by moving construction (emplace) there.

Then it takes advantage of this to refactor the inplace policy to just use a boolean flag to indicate whether an object exists in its storage. This flag is optimized away (using `boost::compressed_pair`, which performs the empty base optimisation) for the `always_inline` policy by using an empty struct, convertible to `bool` as its flag.

PS I've been looking a bit at the way we handle allocators and doing some experimenting with it in [my allocator-refactor branch](https://github.com/yet-another-user/pimpl/compare/master...muggenhor:allocator-refactor). In short: we currently don't use all the typedefs correctly (pointers mainly), nor do we support stateful allocators (that requires an API change).