### PR TITLE
Add full allocator support

### DIFF
--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -31,11 +31,10 @@ struct impl_ptr_policy::copied
 
     template<typename alloc_arg, typename... arg_types>
     copied(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
-    {
-        emplace<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
-    }
+        : impl_(traits_type::template make<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...))
+    {}
 
-    copied (std::nullptr_t) {}
+    copied (std::nullptr_t, const allocator_type& a) : impl_(nullptr, a) {}
     copied (this_type&& o) = default;
     copied (this_type const& o)
         : impl_(nullptr, o.get_allocator())

--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -19,12 +19,13 @@ struct impl_ptr_policy::copied
     using   this_type = copied;
     using traits_type = detail::traits::copyable<impl_type, allocator>;
     using    ptr_type = typename traits_type::ptr_type;
+    using  alloc_type = typename traits_type::alloc_type;
 
     template<typename derived_type, typename... arg_types>
     void
     emplace(arg_types&&... args)
     {
-        impl_ = traits_type::template make<derived_type>(detail::in_place_type(), std::forward<arg_types>(args)...);
+        impl_ = traits_type::template make<derived_type>(std::allocator_arg, alloc_type(), std::forward<arg_types>(args)...);
     }
 
     template<typename... arg_types>
@@ -37,18 +38,20 @@ struct impl_ptr_policy::copied
     copied (this_type&& o) = default;
     copied (this_type const& o)
     {
+        alloc_type a;
         if (o.impl_)
-            impl_ = traits_type::make(*o.impl_);
+            impl_ = traits_type::make(a, *o.impl_);
     }
 
     bool       operator< (this_type const& o) const { return impl_ < o.impl_; }
     this_type& operator= (this_type&& o) { swap(o); return *this; }
     this_type& operator= (this_type const& o)
     {
+        alloc_type a;
         /**/ if ( impl_ ==  o.impl_);
         else if ( impl_ &&  o.impl_) traits_type::assign(impl_.get(), *o.impl_);
         else if ( impl_ && !o.impl_) impl_.reset();
-        else if (!impl_ &&  o.impl_) impl_ = traits_type::make(*o.impl_);
+        else if (!impl_ &&  o.impl_) impl_ = traits_type::make(a, *o.impl_);
 
         return *this;
     }

--- a/include/detail/copied.hpp
+++ b/include/detail/copied.hpp
@@ -6,6 +6,7 @@
 #ifndef IMPL_PTR_DETAIL_COPIED_HPP
 #define IMPL_PTR_DETAIL_COPIED_HPP
 
+#include <memory>
 #include "./detail.hpp"
 
 namespace impl_ptr_policy
@@ -16,38 +17,38 @@ namespace impl_ptr_policy
 template<typename impl_type, typename allocator>
 struct impl_ptr_policy::copied
 {
-    using   this_type = copied;
-    using traits_type = detail::traits::copyable<impl_type, allocator>;
-    using    ptr_type = typename traits_type::ptr_type;
-    using  alloc_type = typename traits_type::alloc_type;
+    using      this_type = copied;
+    using    traits_type = detail::traits::copyable<impl_type, allocator>;
+    using       ptr_type = typename traits_type::ptr_type;
+    using allocator_type = typename traits_type::alloc_type;
 
-    template<typename derived_type, typename... arg_types>
+    template<typename derived_type, typename alloc_arg, typename... arg_types>
     void
-    emplace(arg_types&&... args)
+    emplace(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        impl_ = traits_type::template make<derived_type>(std::allocator_arg, alloc_type(), std::forward<arg_types>(args)...);
+        impl_ = traits_type::template make<derived_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
-    template<typename... arg_types>
-    copied(detail::in_place_type, arg_types&&... args)
+    template<typename alloc_arg, typename... arg_types>
+    copied(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        emplace<impl_type>(std::forward<arg_types>(args)...);
+        emplace<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
     copied (std::nullptr_t) {}
     copied (this_type&& o) = default;
     copied (this_type const& o)
+        : impl_(nullptr, o.get_allocator())
     {
-        alloc_type a;
         if (o.impl_)
-            impl_ = traits_type::make(a, *o.impl_);
+            impl_ = traits_type::make(get_allocator(), *o.impl_);
     }
 
     bool       operator< (this_type const& o) const { return impl_ < o.impl_; }
     this_type& operator= (this_type&& o) { swap(o); return *this; }
     this_type& operator= (this_type const& o)
     {
-        alloc_type a;
+        allocator_type a(o.get_allocator());
         /**/ if ( impl_ ==  o.impl_);
         else if ( impl_ &&  o.impl_) traits_type::assign(impl_.get(), *o.impl_);
         else if ( impl_ && !o.impl_) impl_.reset();
@@ -60,7 +61,11 @@ struct impl_ptr_policy::copied
     impl_type* get () const { return boost::to_address(impl_.get()); }
     long use_count () const { return 1; }
 
-    private: ptr_type impl_;
+    private:
+    allocator_type const& get_allocator() const { return impl_.get_deleter().get_allocator(); }
+    allocator_type      & get_allocator()       { return impl_.get_deleter().get_allocator(); }
+
+    ptr_type impl_;
 };
 
 #endif // IMPL_PTR_DETAIL_COPIED_HPP

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -98,7 +98,6 @@ struct detail::traits::base
 
         void operator()(pointer ip) { base::destroy(get_allocator(), ip); }
 
-        deleter() = default;
         constexpr deleter(const allocator_type& a) : allocator_type(a) {}
         constexpr             allocator_type const& get_allocator() const { return *this; }
         BOOST_CXX14_CONSTEXPR allocator_type      & get_allocator()       { return *this; }

--- a/include/detail/detail.hpp
+++ b/include/detail/detail.hpp
@@ -94,7 +94,7 @@ struct detail::traits::base
     {
         // type used by unique_ptr as replacement for T*
         using pointer = base::pointer;
-        void operator()(pointer ip) const { base::destroy(ip); }
+        void operator()(pointer ip) const { alloc_type a; base::destroy(a, ip); }
     };
 
     virtual ~base() =default;
@@ -114,46 +114,45 @@ struct detail::traits::base
         alloc_traits::construct(alloc, p, std::forward<arg_types>(args)...);
     }
 
-    template<typename derived_type, typename... arg_types>
-    static ptr_type make(detail::in_place_type, arg_types&&... args)
+    template<typename derived_type, typename allocator, typename... arg_types>
+    static ptr_type make(std::allocator_arg_t, allocator&& a0, arg_types&&... args)
     {
-        using    alloc_type = typename alloc_traits::template rebind_alloc<derived_type>;
+        using    alloc_type = typename std::allocator_traits<typename std::decay<allocator>::type>::template rebind_alloc<derived_type>;
         using  alloc_traits = std::allocator_traits<alloc_type>;
         using dealloc_guard = detail::dealloc_guard<alloc_type>;
 
-        alloc_type     a;
+        alloc_type     a(std::forward<allocator>(a0));
         dealloc_guard ap(a, alloc_traits::allocate(a, 1));
 
         emplace(a, ap.get(), std::forward<arg_types>(args)...);
         return ptr_type(ap.release());
     }
 
-    static void       destroy (pointer p                       ) { return traits_->do_destroy  (p                 ); }
-    static void        assign (pointer p, impl_type const& from) { return traits_->do_assign   (p,           from ); }
-    static void        assign (pointer p, impl_type     && from) { return traits_->do_assign   (p, std::move(from)); }
-    static void     construct (void*   p, impl_type const& from) { return traits_->do_construct(p,           from ); }
-    static void     construct (void*   p, impl_type     && from) { return traits_->do_construct(p, std::move(from)); }
-    static ptr_type      make (           impl_type const& from) { return traits_->do_make     (             from ); }
-    static ptr_type      make (           impl_type     && from) { return traits_->do_make     (   std::move(from)); }
+    static void       destroy (alloc_type& a, pointer p                       ) { return traits_->do_destroy  (a, p                 ); }
+    static void        assign (               pointer p, impl_type const& from) { return traits_->do_assign   (   p,           from ); }
+    static void        assign (               pointer p, impl_type     && from) { return traits_->do_assign   (   p, std::move(from)); }
+    static void     construct (alloc_type& a, void*   p, impl_type const& from) { return traits_->do_construct(a, p,           from ); }
+    static void     construct (alloc_type& a, void*   p, impl_type     && from) { return traits_->do_construct(a, p, std::move(from)); }
+    static ptr_type      make (alloc_type& a,            impl_type const& from) { return traits_->do_make     (a,              from ); }
+    static ptr_type      make (alloc_type& a,            impl_type     && from) { return traits_->do_make     (a,    std::move(from)); }
 
     protected:
 
-    void destroy_(pointer p) const
+    void destroy_(alloc_type& a, pointer p) const
     {
-        alloc_type a;
         dealloc_guard<alloc_type> ap(a, std::move(p));
         alloc_traits::destroy(a, ap.get());
     }
 
     private:
 
-    virtual void       do_destroy (pointer) const =0;
+    virtual void       do_destroy (alloc_type&, pointer) const =0;
     virtual void        do_assign (pointer, impl_type const&) const =0;
     virtual void        do_assign (pointer, impl_type&&) const =0;
-    virtual void     do_construct (void*, impl_type const&) const =0;
-    virtual void     do_construct (void*, impl_type&& ) const =0;
-    virtual ptr_type      do_make (impl_type const&) const =0;
-    virtual ptr_type      do_make (impl_type&& ) const =0;
+    virtual void     do_construct (alloc_type&, void*, impl_type const&) const =0;
+    virtual void     do_construct (alloc_type&, void*, impl_type&& ) const =0;
+    virtual ptr_type      do_make (alloc_type&, impl_type const&) const =0;
+    virtual ptr_type      do_make (alloc_type&, impl_type&& ) const =0;
 
     static void construct_singleton()
     {
@@ -172,18 +171,19 @@ detail::traits::base<traits_type, impl_type, alloc_type>::traits_;
 template<typename impl_type, typename allocator>
 struct detail::traits::unique final : base<unique<impl_type, allocator>, impl_type, allocator>
 {
-    using this_type = unique<impl_type, allocator>;
-    using base_type = base<this_type, impl_type, allocator>;
-    using   pointer = typename base_type::pointer;
-    using  ptr_type = typename base_type::ptr_type;
+    using  this_type = unique<impl_type, allocator>;
+    using  base_type = base<this_type, impl_type, allocator>;
+    using alloc_type = typename base_type::alloc_type;
+    using    pointer = typename base_type::pointer;
+    using   ptr_type = typename base_type::ptr_type;
 
-    void       do_destroy (pointer p                  ) const override { this->destroy_(p); }
-    void        do_assign (pointer  , impl_type const&) const override { BOOST_ASSERT(!"not implemented"); }
-    void        do_assign (pointer  , impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); }
-    void     do_construct (void*    , impl_type const&) const override { BOOST_ASSERT(!"not implemented"); }
-    void     do_construct (void*    , impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); }
-    ptr_type      do_make (           impl_type const&) const override { BOOST_ASSERT(!"not implemented"); return nullptr; }
-    ptr_type      do_make (           impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); return nullptr; }
+    void       do_destroy (alloc_type& a, pointer p                  ) const override { this->destroy_(a, p); }
+    void        do_assign (               pointer  , impl_type const&) const override { BOOST_ASSERT(!"not implemented"); }
+    void        do_assign (               pointer  , impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); }
+    void     do_construct (alloc_type&  , void*    , impl_type const&) const override { BOOST_ASSERT(!"not implemented"); }
+    void     do_construct (alloc_type&  , void*    , impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); }
+    ptr_type      do_make (alloc_type&  ,            impl_type const&) const override { BOOST_ASSERT(!"not implemented"); return nullptr; }
+    ptr_type      do_make (alloc_type&  ,            impl_type&&     ) const override { BOOST_ASSERT(!"not implemented"); return nullptr; }
 };
 
 template<typename impl_type, typename allocator>
@@ -196,29 +196,27 @@ struct detail::traits::copyable final : base<copyable<impl_type, allocator>, imp
     using      pointer = typename base_type::pointer;
     using     ptr_type = typename base_type::ptr_type;
 
-    void do_destroy(pointer p) const override { this->destroy_(p); }
+    void do_destroy(alloc_type& a, pointer p) const override { this->destroy_(a, p); }
 
     void
-    do_construct(void* vp, impl_type const& from) const override
+    do_construct(alloc_type& a, void* vp, impl_type const& from) const override
     {
-        alloc_type a;
         this->emplace(a, static_cast<impl_type*>(vp), from);
     }
     void
-    do_construct(void* vp, impl_type&& from) const override
+    do_construct(alloc_type& a, void* vp, impl_type&& from) const override
     {
-        alloc_type a;
         this->emplace(a, static_cast<impl_type*>(vp), std::move(from));
     }
     ptr_type
-    do_make(impl_type const& from) const override
+    do_make(alloc_type& a, impl_type const& from) const override
     {
-        return this->template make<impl_type>(in_place_type(), from);
+        return this->template make<impl_type>(std::allocator_arg, a, from);
     }
     ptr_type
-    do_make(impl_type&& from) const override
+    do_make(alloc_type& a, impl_type&& from) const override
     {
-        return this->template make<impl_type>(in_place_type(), std::move(from));
+        return this->template make<impl_type>(std::allocator_arg, a, std::move(from));
     }
     void
     do_assign(pointer p, impl_type const& from) const override

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -135,7 +135,7 @@ struct detail::basic_inplace // Proof of concept
         if (exists())
             traits_type::destroy(a, get());
     }
-    BOOST_CXX14_CONSTEXPR basic_inplace (std::nullptr_t)
+    BOOST_CXX14_CONSTEXPR basic_inplace (std::nullptr_t, const allocator_type&)
     {
         static_assert(exists_type(false) == false, "Constructing null-state is prohibited.");
     }

--- a/include/detail/inplace.hpp
+++ b/include/detail/inplace.hpp
@@ -115,8 +115,9 @@ struct detail::basic_inplace // Proof of concept
 
    ~basic_inplace ()
     {
+        alloc_type a;
         if (exists())
-            traits_type::destroy(get());
+            traits_type::destroy(a, get());
     }
     BOOST_CXX14_CONSTEXPR basic_inplace (std::nullptr_t)
     {
@@ -151,8 +152,9 @@ struct detail::basic_inplace // Proof of concept
         static_assert(exists_type(false) == false, "Emplacing to storage that doesn't support null-state is prohibited.");
         if (exists())
         {
+            alloc_type a;
             set_exists(false);
-            traits_type::destroy(get());
+            traits_type::destroy(a, get());
         }
         return _construct<derived_type>(std::forward<arg_types>(args)...);
     }
@@ -184,10 +186,11 @@ struct detail::basic_inplace // Proof of concept
         const bool   exists = this->exists();
         const bool o_exists =     o.exists();
 
+        alloc_type a;
         /**/ if (!exists && !o_exists);
         else if ( exists &&  o_exists) traits_type::assign(get(), std::forward<uref>(*o.get()));
-        else if ( exists && !o_exists) { set_exists(false); traits_type::destroy(get()); }
-        else if (!exists &&  o_exists) { traits_type::construct(storage().address(), std::forward<uref>(*o.get())); set_exists(true); }
+        else if ( exists && !o_exists) { set_exists(false); traits_type::destroy(a, get()); }
+        else if (!exists &&  o_exists) { traits_type::construct(a, storage().address(), std::forward<uref>(*o.get())); set_exists(true); }
 
         return *this;
     }

--- a/include/detail/shared.hpp
+++ b/include/detail/shared.hpp
@@ -20,9 +20,11 @@ struct impl_ptr_policy::shared : std::shared_ptr<impl_type>
 
     template<typename derived_type, typename alloc_arg, typename... arg_types>
     void
-    emplace(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
+    emplace(std::allocator_arg_t, alloc_arg&& a0, arg_types&&... args)
     {
-        base_ref(*this) = std::allocate_shared<derived_type>(std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
+        using alloc_type = typename std::allocator_traits<allocator_type>::template rebind_alloc<derived_type>;
+        alloc_type a(std::forward<alloc_arg>(a0));
+        base_ref(*this) = std::allocate_shared<derived_type>(a, std::forward<arg_types>(args)...);
     }
 
     shared(std::nullptr_t, const allocator_type&) {}

--- a/include/detail/shared.hpp
+++ b/include/detail/shared.hpp
@@ -25,7 +25,7 @@ struct impl_ptr_policy::shared : std::shared_ptr<impl_type>
         base_ref(*this) = std::allocate_shared<derived_type>(std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
-    shared(std::nullptr_t) {}
+    shared(std::nullptr_t, const allocator_type&) {}
 
     template<typename alloc_arg, typename... arg_types>
     shared(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)

--- a/include/detail/shared.hpp
+++ b/include/detail/shared.hpp
@@ -15,22 +15,22 @@ namespace impl_ptr_policy
 template<typename impl_type, typename allocator>
 struct impl_ptr_policy::shared : std::shared_ptr<impl_type>
 {
-    using alloc_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
-    using   base_ref = std::shared_ptr<impl_type>&;
+    using allocator_type = typename std::allocator_traits<allocator>::template rebind_alloc<impl_type>;
+    using       base_ref = std::shared_ptr<impl_type>&;
 
-    template<typename derived_type, typename... arg_types>
+    template<typename derived_type, typename alloc_arg, typename... arg_types>
     void
-    emplace(arg_types&&... args)
+    emplace(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        base_ref(*this) = std::allocate_shared<derived_type>(alloc_type(), std::forward<arg_types>(args)...);
+        base_ref(*this) = std::allocate_shared<derived_type>(std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
     shared(std::nullptr_t) {}
 
-    template<typename... arg_types>
-    shared(detail::in_place_type, arg_types&&... args)
+    template<typename alloc_arg, typename... arg_types>
+    shared(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        emplace<impl_type>(std::forward<arg_types>(args)...);
+        emplace<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 };
 

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -6,6 +6,7 @@
 #ifndef IMPL_PTR_DETAIL_UNIQUE_HPP
 #define IMPL_PTR_DETAIL_UNIQUE_HPP
 
+#include <memory>
 #include "./detail.hpp"
 
 namespace impl_ptr_policy
@@ -16,22 +17,22 @@ namespace impl_ptr_policy
 template<typename impl_type, typename allocator>
 struct impl_ptr_policy::unique
 {
-    using   this_type = unique;
-    using traits_type = detail::traits::unique<impl_type, allocator>;
-    using    ptr_type = typename traits_type::ptr_type;
-    using  alloc_type = typename traits_type::alloc_type;
+    using      this_type = unique;
+    using    traits_type = detail::traits::unique<impl_type, allocator>;
+    using       ptr_type = typename traits_type::ptr_type;
+    using allocator_type = typename traits_type::alloc_type;
 
-    template<typename derived_type, typename... arg_types>
+    template<typename derived_type, typename alloc_arg, typename... arg_types>
     void
-    emplace(arg_types&&... args)
+    emplace(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        impl_ = traits_type::template make<derived_type>(std::allocator_arg, alloc_type(), std::forward<arg_types>(args)...);
+        impl_ = traits_type::template make<derived_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
-    template<typename... arg_types>
-    unique(detail::in_place_type, arg_types&&... args)
+    template<typename alloc_arg, typename... arg_types>
+    unique(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
     {
-        emplace<impl_type>(std::forward<arg_types>(args)...);
+        emplace<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
     }
 
     unique (std::nullptr_t) {}

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -19,12 +19,13 @@ struct impl_ptr_policy::unique
     using   this_type = unique;
     using traits_type = detail::traits::unique<impl_type, allocator>;
     using    ptr_type = typename traits_type::ptr_type;
+    using  alloc_type = typename traits_type::alloc_type;
 
     template<typename derived_type, typename... arg_types>
     void
     emplace(arg_types&&... args)
     {
-        impl_ = traits_type::template make<derived_type>(detail::in_place_type(), std::forward<arg_types>(args)...);
+        impl_ = traits_type::template make<derived_type>(std::allocator_arg, alloc_type(), std::forward<arg_types>(args)...);
     }
 
     template<typename... arg_types>

--- a/include/detail/unique.hpp
+++ b/include/detail/unique.hpp
@@ -31,11 +31,10 @@ struct impl_ptr_policy::unique
 
     template<typename alloc_arg, typename... arg_types>
     unique(std::allocator_arg_t, alloc_arg&& a, arg_types&&... args)
-    {
-        emplace<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...);
-    }
+        : impl_(traits_type::template make<impl_type>(std::allocator_arg, std::forward<alloc_arg>(a), std::forward<arg_types>(args)...))
+    {}
 
-    unique (std::nullptr_t) {}
+    unique (std::nullptr_t, const allocator_type& a) : impl_(nullptr, a) {}
 
     unique (this_type&& o) = default;
     this_type& operator= (this_type&& o) { swap(o); return *this; }

--- a/include/impl_ptr.hpp
+++ b/include/impl_ptr.hpp
@@ -112,7 +112,10 @@ struct impl_ptr
 
     template<typename, template<typename, typename...> class, typename...> friend struct impl_ptr;
 
-    impl_ptr(std::nullptr_t) : impl_(nullptr) {}
+    impl_ptr(std::nullptr_t) : impl_(nullptr, typename policy_type::allocator_type()) {}
+
+    template <typename allocator, typename = typename std::enable_if<std::uses_allocator<policy_type, allocator>::value>::type>
+    impl_ptr(std::nullptr_t, allocator&& a) : impl_(nullptr, std::forward<allocator>(a)) {}
 
     template<typename allocator, typename... arg_types
         , typename = typename std::enable_if<std::uses_allocator<policy_type, allocator>::value>::type>

--- a/include/impl_ptr.hpp
+++ b/include/impl_ptr.hpp
@@ -71,19 +71,33 @@ struct impl_ptr
     void      swap (user_type& that) { impl_.swap(that.impl_); }
     long use_count () const { return impl_.use_count(); }
 
+    template<typename derived_impl_type, typename allocator, typename... arg_types
+        , typename = typename std::enable_if<std::uses_allocator<policy_type, allocator>::value>::type>
+    void
+    emplace(std::allocator_arg_t, allocator&& a, arg_types&&... args)
+    {
+        static_assert(std::is_base_of<impl_type, derived_impl_type>::value, "");
+
+        impl_.template emplace<derived_impl_type>(std::allocator_arg, std::forward<allocator>(a), std::forward<arg_types>(args)...);
+    }
+    template<typename allocator, typename... arg_types
+        , typename = typename std::enable_if<std::uses_allocator<policy_type, allocator>::value>::type>
+    void
+    emplace(std::allocator_arg_t, allocator&& a, arg_types&&... args)
+    {
+        impl_.template emplace<impl_type>(std::allocator_arg, std::forward<allocator>(a), std::forward<arg_types>(args)...);
+    }
     template<typename derived_impl_type, typename... arg_types>
     void
     emplace(arg_types&&... args)
     {
-        static_assert(std::is_base_of<impl_type, derived_impl_type>::value, "");
-
-        impl_.template emplace<derived_impl_type>(std::forward<arg_types>(args)...);
+        return emplace<derived_impl_type>(std::allocator_arg, typename policy_type::allocator_type(), std::forward<arg_types>(args)...);
     }
     template<typename... arg_types>
     void
     emplace(arg_types&&... args)
     {
-        impl_.template emplace<impl_type>(std::forward<arg_types>(args)...);
+        return emplace(std::allocator_arg, typename policy_type::allocator_type(), std::forward<arg_types>(args)...);
     }
 
     // Access To the Implementation.
@@ -100,10 +114,17 @@ struct impl_ptr
 
     impl_ptr(std::nullptr_t) : impl_(nullptr) {}
 
+    template<typename allocator, typename... arg_types
+        , typename = typename std::enable_if<std::uses_allocator<policy_type, allocator>::value>::type>
+    impl_ptr(std::allocator_arg_t, allocator&& a, arg_types&&... args)
+    :
+        impl_(std::allocator_arg, std::forward<allocator>(a), std::forward<arg_types>(args)...)
+    {}
+
     template<typename... arg_types>
     impl_ptr(detail::in_place_type, arg_types&&... args)
     :
-        impl_(in_place, std::forward<arg_types>(args)...)
+        impl_ptr(std::allocator_arg, typename policy_type::allocator_type(), std::forward<arg_types>(args)...)
     {}
 
     private: policy_type impl_;

--- a/test/impl_always_inplace.cpp
+++ b/test/impl_always_inplace.cpp
@@ -3,8 +3,9 @@
 template<> struct boost::impl_ptr<AlwaysInPlace>::implementation
 {
     using this_type = implementation;
+    using allocator_type = std::allocator<void>;
 
-    implementation ()           : int_(0), trace_("AlwaysInPlace()"          ) {}
+    implementation (const std::allocator<void>&) : int_(0), trace_("AlwaysInPlace()"          ) {}
     implementation (int k)      : int_(k), trace_("AlwaysInPlace(int)"       ) {}
     implementation (int k, int) : int_(k), trace_("AlwaysInPlace(int, int)"  ) {}
     implementation (Foo&)       : int_(0), trace_("AlwaysInPlace(Foo&)"      ) {}
@@ -30,7 +31,7 @@ static_assert(sizeof(AlwaysInPlace) == sizeof(boost::impl_ptr<AlwaysInPlace>::im
 static_assert(alignof(AlwaysInPlace) == alignof(boost::impl_ptr<AlwaysInPlace>::implementation),
         "No memory alignment overhead for always_inplace is permitted");
 
-AlwaysInPlace::AlwaysInPlace ()      : impl_ptr_type(in_place) {}
+AlwaysInPlace::AlwaysInPlace ()      : impl_ptr_type(in_place, std::allocator<void>{}) {}
 AlwaysInPlace::AlwaysInPlace (int k) : impl_ptr_type(in_place, k) {}
 
 string AlwaysInPlace::trace () const { return *this ? (*this)->trace_ : "null"; }

--- a/test/impl_copied.cpp
+++ b/test/impl_copied.cpp
@@ -34,7 +34,7 @@ template<> struct boost::impl_ptr<Copied>::implementation
     mutable string trace_;
 };
 
-Copied::Copied ()      : impl_ptr_type(in_place) {}
+Copied::Copied ()      : impl_ptr_type(std::allocator_arg, std::allocator<void>()) {}
 Copied::Copied (int k) : impl_ptr_type(in_place, k) {}
 
 string Copied::trace () const { return *this ? (*this)->trace_ : "null"; }

--- a/test/impl_shared.cpp
+++ b/test/impl_shared.cpp
@@ -36,7 +36,7 @@ int    Shared::value () const { return (*this)->int_; }
 Shared::Shared ()             : impl_ptr_type(in_place) {}
 Shared::Shared (int k)        : impl_ptr_type(in_place, k) {}
 Shared::Shared (int k, int l) : impl_ptr_type(in_place, k, l) {}
-Shared::Shared (Foo&       f) : impl_ptr_type(in_place, f) {} // Testing that 'const' handled properly
+Shared::Shared (Foo&       f) : impl_ptr_type(std::allocator_arg, std::allocator<void>(), f) {} // Testing that 'const' handled properly
 Shared::Shared (Foo const& f) : impl_ptr_type(in_place, f) {} // Testing that 'const' handled properly
 Shared::Shared (Foo*       f) : impl_ptr_type(in_place, f) {} // Testing that 'const' handled properly
 Shared::Shared (Foo const* f) : impl_ptr_type(in_place, f) {} // Testing that 'const' handled properly

--- a/test/impl_unique.cpp
+++ b/test/impl_unique.cpp
@@ -17,7 +17,7 @@ template<> struct boost::impl_ptr<Unique>::implementation
     mutable string trace_;
 };
 
-Unique::Unique ()      : impl_ptr_type(in_place) {}
+Unique::Unique ()      : impl_ptr_type(std::allocator_arg, std::allocator<void>()) {}
 Unique::Unique (int k) : impl_ptr_type(in_place, k) {}
 
 string Unique::trace () const { return *this ? (*this)->trace_ : "null"; }


### PR DESCRIPTION
This required very careful reading of the C++ spec to get right. But I'm now pretty sure that this is how allocators are supposed to be used by containers. `impl_ptr` is basically a single-item container for the purpose of allocator treatment.